### PR TITLE
feat/NOC-41-add-article-hero-section

### DIFF
--- a/app/blog/[postSlug]/layout.tsx
+++ b/app/blog/[postSlug]/layout.tsx
@@ -3,5 +3,5 @@ export default async function Layout({
 }: {
   children: React.ReactNode;
 }) {
-  return <div className='mx-auto max-w-7xl px-6 py-20 relative'>{children}</div>;
+  return <div className='mx-auto max-w-7xl px-6 py-14 md:py-20 relative'>{children}</div>;
 }

--- a/app/blog/[postSlug]/page.tsx
+++ b/app/blog/[postSlug]/page.tsx
@@ -19,12 +19,27 @@ export default async function Page({ params }: PageProps) {
     notFound();
   }
 
+  const { title, author, createdAt, tags, featuredImage, content } = post;
+
   const { sanitizedHtmlContent, tocArray } = sanitizeHtmlContentAndGenerateTOC(
-    post.content.html
+    content.html
   );
 
   return (
     <ArticlePage
+      title={title}
+      author={
+        author
+          ? {
+              name: author.name,
+              photo: author.photo.url,
+              socialMediaLinks: author.socialMediaLinks,
+            }
+          : null
+      }
+      createdAt={createdAt}
+      tags={tags.map(({ name, slug }) => ({ name, slug }))}
+      featuredImage={featuredImage.url}
       sanitizedHtmlContent={sanitizedHtmlContent}
       tocArray={tocArray}
     />

--- a/components/blog/ArticleHero.tsx
+++ b/components/blog/ArticleHero.tsx
@@ -1,0 +1,75 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { PostCategoryTag } from '#/components/blog/PostCategoryTag';
+import { formatStringDate } from '#/utils/stringDateFormatter';
+
+interface ArticleHeroProps {
+  title: string;
+  author: {
+    name: string;
+    photo: string;
+    socialMediaLinks: Array<string>;
+  } | null;
+  createdAt: string;
+  tags: Array<{ name: string; slug: string }>;
+  featuredImage: string;
+}
+
+export function ArticleHero({
+  title,
+  author,
+  createdAt,
+  tags,
+  featuredImage,
+}: ArticleHeroProps) {
+  return (
+    <div className='flex flex-col gap-7 items-center mb-14'>
+      <h1 className='text-white text-center text-4xl md:text-5xl xl:text-6xl'>
+        {title}
+      </h1>
+      <div className='flex items-center gap-2'>
+        {author && (
+          <Link
+            href={author.socialMediaLinks[0]}
+            className='w-12 h-12 relative'
+          >
+            <Image
+              src={author.photo}
+              fill
+              alt='article author'
+              className='object-cover rounded-full object-top'
+            />
+          </Link>
+        )}
+        <div>
+          {author && (
+            <Link
+              href={author.socialMediaLinks[0]}
+              title={author.name}
+              className='text-lg text-[#00C9F0] hover:text-[#5E94E6] transition-colors'
+            >
+              {author.name}
+            </Link>
+          )}
+          <p className='text-sm text-dusty-gray-700'>
+            {formatStringDate(createdAt, true)}
+          </p>
+        </div>
+      </div>
+      <div className='flex flex-wrap justify-center gap-2.5'>
+        {tags.map(({ name, slug }) => (
+          <PostCategoryTag key={slug} name={name} slug={slug} />
+        ))}
+      </div>
+      <div className='w-full h-96 relative'>
+        <Image
+          src={featuredImage}
+          alt='featured image'
+          fill
+          className='object-cover'
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/blog/ArticlePage.tsx
+++ b/components/blog/ArticlePage.tsx
@@ -1,29 +1,55 @@
 'use client';
 
+import { ArticleHero } from '#/components/blog/ArticleHero';
 import { TableOfContents } from '#/components/blog/TableOfContents';
 import { useHeadersObserver } from '#/utils/hooks/useHeadersObserver';
 import { TocItem } from '#/utils/HtmlSanitizerAndTocGenerator';
 
 interface ArticlePageProps {
+  title: string;
+  author: {
+    name: string;
+    photo: string;
+    socialMediaLinks: Array<string>;
+  } | null;
+  createdAt: string;
+  tags: Array<{ name: string; slug: string }>;
+  featuredImage: string;
   sanitizedHtmlContent: string;
   tocArray: Array<TocItem>;
 }
 
 export function ArticlePage({
+  title,
+  author,
+  createdAt,
+  tags,
+  featuredImage,
   sanitizedHtmlContent,
   tocArray,
 }: ArticlePageProps) {
-  const articleContainerId = 'article-container';
-  const { activeHeaderId } = useHeadersObserver(articleContainerId);
+  const htmlContentContainerId = 'article-container';
+  const { activeHeaderId } = useHeadersObserver(htmlContentContainerId);
   return (
-    // TODO: create loading animation (SVGator?)
-    // TODO: add library for displaying code (pre tags styling)
     <div className='block lg:flex justify-end gap-x-16 items-start'>
-      <article // DL: decided to not use html-react-parse -> content is already sanitized no need to parse it to React components; better performance with setInnerHtml
-        id={articleContainerId}
-        className='prose md:prose-lg xl:prose-xl prose-nocturne mx-auto lg:mr-0'
-        dangerouslySetInnerHTML={{ __html: sanitizedHtmlContent }}
-      ></article>
+      <main>
+        <article className='prose md:prose-lg xl:prose-xl prose-nocturne mx-auto lg:mr-0'>
+          <section className='not-prose'>
+            <ArticleHero
+              title={title}
+              author={author}
+              createdAt={createdAt}
+              tags={tags}
+              featuredImage={featuredImage}
+            />
+          </section>
+          <section
+            id={htmlContentContainerId}
+            // DL: decided to not use html-react-parse -> content is already sanitized no need to parse it to React components; better performance with setInnerHtml
+            dangerouslySetInnerHTML={{ __html: sanitizedHtmlContent }}
+          ></section>
+        </article>
+      </main>
       <TableOfContents tocItemsArray={tocArray} activeItemId={activeHeaderId} />
     </div>
   );

--- a/gql/codegen/gql.ts
+++ b/gql/codegen/gql.ts
@@ -15,7 +15,7 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
 const documents = {
     "\n  query GetAllPosts {\n    posts {\n      slug\n      featuredImage {\n        url\n      }\n      title\n      excerpt\n      author {\n        name\n      }\n      createdAt\n    }\n  }\n": types.GetAllPostsDocument,
     "\n  query GetAllTags {\n    tags {\n      name\n      slug\n    }\n  }\n": types.GetAllTagsDocument,
-    "\n  query GetPostBySlug($slug: String!) {\n    post(where: { slug: $slug }) {\n      id\n      title\n      slug\n      content {\n        html\n      }\n      featuredImage {\n        url\n      }\n    }\n  }\n": types.GetPostBySlugDocument,
+    "\n  query GetPostBySlug($slug: String!) {\n    post(where: { slug: $slug }) {\n      title\n      author {\n        name\n        photo {\n          url\n        }\n        socialMediaLinks\n      }\n      createdAt\n      tags {\n        name\n        slug\n      }\n      content {\n        html\n      }\n      featuredImage {\n        url\n      }\n    }\n  }\n": types.GetPostBySlugDocument,
     "\n  query GetPostHeadInfoBySlug($postSlug: String!) {\n    post(where: { slug: $postSlug }) {\n      title\n      author {\n        name\n      }\n      createdAt\n    }\n  }\n": types.GetPostHeadInfoBySlugDocument,
     "\n  query GetPostsByTagSlug($tagSlug: String!) {\n    posts(where: { tags_some: { slug: $tagSlug } }) {\n      slug\n      featuredImage {\n        url\n      }\n      title\n      excerpt\n      author {\n        name\n      }\n      createdAt\n    }\n  }\n": types.GetPostsByTagSlugDocument,
 };
@@ -31,7 +31,7 @@ export function graphql(source: "\n  query GetAllTags {\n    tags {\n      name\
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query GetPostBySlug($slug: String!) {\n    post(where: { slug: $slug }) {\n      id\n      title\n      slug\n      content {\n        html\n      }\n      featuredImage {\n        url\n      }\n    }\n  }\n"): (typeof documents)["\n  query GetPostBySlug($slug: String!) {\n    post(where: { slug: $slug }) {\n      id\n      title\n      slug\n      content {\n        html\n      }\n      featuredImage {\n        url\n      }\n    }\n  }\n"];
+export function graphql(source: "\n  query GetPostBySlug($slug: String!) {\n    post(where: { slug: $slug }) {\n      title\n      author {\n        name\n        photo {\n          url\n        }\n        socialMediaLinks\n      }\n      createdAt\n      tags {\n        name\n        slug\n      }\n      content {\n        html\n      }\n      featuredImage {\n        url\n      }\n    }\n  }\n"): (typeof documents)["\n  query GetPostBySlug($slug: String!) {\n    post(where: { slug: $slug }) {\n      title\n      author {\n        name\n        photo {\n          url\n        }\n        socialMediaLinks\n      }\n      createdAt\n      tags {\n        name\n        slug\n      }\n      content {\n        html\n      }\n      featuredImage {\n        url\n      }\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/gql/codegen/graphql.ts
+++ b/gql/codegen/graphql.ts
@@ -753,7 +753,7 @@ export type Author = Node & {
   /** Name of the author */
   name: Scalars['String'];
   /** Photo of the author */
-  photo?: Maybe<Asset>;
+  photo: Asset;
   /** Posts written by this author */
   posts: Array<Post>;
   /** The time the document was published. Null on documents in draft stage. */
@@ -761,6 +761,8 @@ export type Author = Node & {
   /** User that last published this document */
   publishedBy?: Maybe<User>;
   scheduledIn: Array<ScheduledOperation>;
+  /** Link to social media accounts of article author */
+  socialMediaLinks: Array<Scalars['String']>;
   /** System stage field */
   stage: Stage;
   /** The time the document was updated */
@@ -861,8 +863,9 @@ export type AuthorCreateInput = {
   bio?: InputMaybe<Scalars['String']>;
   createdAt?: InputMaybe<Scalars['DateTime']>;
   name: Scalars['String'];
-  photo?: InputMaybe<AssetCreateOneInlineInput>;
+  photo: AssetCreateOneInlineInput;
   posts?: InputMaybe<PostCreateManyInlineInput>;
+  socialMediaLinks: Array<Scalars['String']>;
   updatedAt?: InputMaybe<Scalars['DateTime']>;
 };
 
@@ -998,6 +1001,16 @@ export type AuthorManyWhereInput = {
   scheduledIn_every?: InputMaybe<ScheduledOperationWhereInput>;
   scheduledIn_none?: InputMaybe<ScheduledOperationWhereInput>;
   scheduledIn_some?: InputMaybe<ScheduledOperationWhereInput>;
+  /** Matches if the field array contains *all* items provided to the filter and order does match */
+  socialMediaLinks?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array contains *all* items provided to the filter */
+  socialMediaLinks_contains_all?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array does not contain any of the items provided to the filter */
+  socialMediaLinks_contains_none?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array contains at least one item provided to the filter */
+  socialMediaLinks_contains_some?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array does not contains *all* items provided to the filter or order does not match */
+  socialMediaLinks_not?: InputMaybe<Array<Scalars['String']>>;
   updatedAt?: InputMaybe<Scalars['DateTime']>;
   /** All values greater than the given value. */
   updatedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -1027,6 +1040,8 @@ export enum AuthorOrderByInput {
   NameDesc = 'name_DESC',
   PublishedAtAsc = 'publishedAt_ASC',
   PublishedAtDesc = 'publishedAt_DESC',
+  SocialMediaLinksAsc = 'socialMediaLinks_ASC',
+  SocialMediaLinksDesc = 'socialMediaLinks_DESC',
   UpdatedAtAsc = 'updatedAt_ASC',
   UpdatedAtDesc = 'updatedAt_DESC'
 }
@@ -1036,6 +1051,7 @@ export type AuthorUpdateInput = {
   name?: InputMaybe<Scalars['String']>;
   photo?: InputMaybe<AssetUpdateOneInlineInput>;
   posts?: InputMaybe<PostUpdateManyInlineInput>;
+  socialMediaLinks?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AuthorUpdateManyInlineInput = {
@@ -1058,6 +1074,7 @@ export type AuthorUpdateManyInlineInput = {
 export type AuthorUpdateManyInput = {
   bio?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
+  socialMediaLinks?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type AuthorUpdateManyWithNestedWhereInput = {
@@ -1218,6 +1235,16 @@ export type AuthorWhereInput = {
   scheduledIn_every?: InputMaybe<ScheduledOperationWhereInput>;
   scheduledIn_none?: InputMaybe<ScheduledOperationWhereInput>;
   scheduledIn_some?: InputMaybe<ScheduledOperationWhereInput>;
+  /** Matches if the field array contains *all* items provided to the filter and order does match */
+  socialMediaLinks?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array contains *all* items provided to the filter */
+  socialMediaLinks_contains_all?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array does not contain any of the items provided to the filter */
+  socialMediaLinks_contains_none?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array contains at least one item provided to the filter */
+  socialMediaLinks_contains_some?: InputMaybe<Array<Scalars['String']>>;
+  /** Matches if the field array does not contains *all* items provided to the filter or order does not match */
+  socialMediaLinks_not?: InputMaybe<Array<Scalars['String']>>;
   updatedAt?: InputMaybe<Scalars['DateTime']>;
   /** All values greater than the given value. */
   updatedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -5124,7 +5151,7 @@ export type GetPostBySlugQueryVariables = Exact<{
 }>;
 
 
-export type GetPostBySlugQuery = { __typename?: 'Query', post?: { __typename?: 'Post', id: string, title: string, slug: string, content: { __typename?: 'PostContentRichText', html: string }, featuredImage: { __typename?: 'Asset', url: string } } | null };
+export type GetPostBySlugQuery = { __typename?: 'Query', post?: { __typename?: 'Post', title: string, createdAt: any, author?: { __typename?: 'Author', name: string, socialMediaLinks: Array<string>, photo: { __typename?: 'Asset', url: string } } | null, tags: Array<{ __typename?: 'Tag', name: string, slug: string }>, content: { __typename?: 'PostContentRichText', html: string }, featuredImage: { __typename?: 'Asset', url: string } } | null };
 
 export type GetPostHeadInfoBySlugQueryVariables = Exact<{
   postSlug: Scalars['String'];
@@ -5143,6 +5170,6 @@ export type GetPostsByTagSlugQuery = { __typename?: 'Query', posts: Array<{ __ty
 
 export const GetAllPostsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAllPosts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"posts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"featuredImage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"excerpt"}},{"kind":"Field","name":{"kind":"Name","value":"author"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]} as unknown as DocumentNode<GetAllPostsQuery, GetAllPostsQueryVariables>;
 export const GetAllTagsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAllTags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}}]}}]}}]} as unknown as DocumentNode<GetAllTagsQuery, GetAllTagsQueryVariables>;
-export const GetPostBySlugDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetPostBySlug"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"slug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"post"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"slug"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"content"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"html"}}]}},{"kind":"Field","name":{"kind":"Name","value":"featuredImage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}}]}}]}}]} as unknown as DocumentNode<GetPostBySlugQuery, GetPostBySlugQueryVariables>;
+export const GetPostBySlugDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetPostBySlug"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"slug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"post"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"slug"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"author"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"photo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}},{"kind":"Field","name":{"kind":"Name","value":"socialMediaLinks"}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}}]}},{"kind":"Field","name":{"kind":"Name","value":"content"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"html"}}]}},{"kind":"Field","name":{"kind":"Name","value":"featuredImage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}}]}}]}}]} as unknown as DocumentNode<GetPostBySlugQuery, GetPostBySlugQueryVariables>;
 export const GetPostHeadInfoBySlugDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetPostHeadInfoBySlug"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"postSlug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"post"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"postSlug"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"author"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]} as unknown as DocumentNode<GetPostHeadInfoBySlugQuery, GetPostHeadInfoBySlugQueryVariables>;
 export const GetPostsByTagSlugDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetPostsByTagSlug"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"tagSlug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"posts"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"tags_some"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"tagSlug"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"slug"}},{"kind":"Field","name":{"kind":"Name","value":"featuredImage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"excerpt"}},{"kind":"Field","name":{"kind":"Name","value":"author"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]} as unknown as DocumentNode<GetPostsByTagSlugQuery, GetPostsByTagSlugQueryVariables>;

--- a/gql/documents/GetPostBySlug.ts
+++ b/gql/documents/GetPostBySlug.ts
@@ -3,9 +3,19 @@ import { graphql } from '#/gql/codegen';
 export const GetPostBySlug = graphql(/* GraphQL */ `
   query GetPostBySlug($slug: String!) {
     post(where: { slug: $slug }) {
-      id
       title
-      slug
+      author {
+        name
+        photo {
+          url
+        }
+        socialMediaLinks
+      }
+      createdAt
+      tags {
+        name
+        slug
+      }
       content {
         html
       }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,7 @@
 
 ::-webkit-scrollbar {
   width: 5px;
+  height: 5px;
 }
 
 ::-webkit-scrollbar-thumb {

--- a/utils/stringDateFormatter.ts
+++ b/utils/stringDateFormatter.ts
@@ -1,22 +1,23 @@
 // TODO: For now the only locale supported is 'en-us' - this could be extended to other locales
 import { formatAsOrdinal } from '#/utils/ordinalFormatter';
 
-export function formatStringDate(dateStringISO: string) {
+export function formatStringDate(dateStringISO: string, withWeekday?: boolean) {
   const date = new Date(dateStringISO);
   const dateFormatter = new Intl.DateTimeFormat('en-us', {
+    ...(withWeekday && { weekday: 'long' }),
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
   const partitionedDate = dateFormatter.formatToParts(date);
 
-  return partitionedDate.reduce((formattedDate, { type, value }) => {
+  return partitionedDate.reduce((formattedDate, { type, value }, currentIndex) => {
     if (type === 'day') {
       // represent day number as ordinal
       value = formatAsOrdinal(value as unknown as number);
     } else if (type === 'literal' && value.includes(',')) {
       // replace commas with space
-      value = ' ';
+      value = withWeekday && currentIndex === 1 ? ', ' : ' '; // do not remove comma after weekday name
     }
     return formattedDate + value;
   }, '');


### PR DESCRIPTION
changelog:
- add hero section for article
- it contains title
- author with image and link to primary social media account (first of social media links - hygraph)
- date with weekday name
- tags from this particular post
- hero image as next/image - not sure if using optimized image from nextjs is the best idea here (if the image contains some text it might not be visible due to object-cover and fixed size of containing div)